### PR TITLE
Update storybook webpack config: override svg loader to use svgr/webpack

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,22 +1,20 @@
 const path = require('path');
 const constants = require('../constants.js');
 
-const { config } = constants;
+const { config, APP_DIR } = constants;
 
-const pathToInlineSvg = path.resolve(__dirname, '../../src/app/components/Icon/svg');
+const pathToInlineSvg = path.resolve(APP_DIR, 'components/Icon/svg');
 
 
 module.exports = ({ config }) => {
-    console.log('pathToInlineSvg', pathToInlineSvg);
     const rules = config.module.rules;
 
-    // // modify storybook's file-loader rule to avoid conflicts with svgr
+    // modify storybook's file-loader rule to avoid conflicts with svgr
     const fileLoaderRule = rules.find(rule => rule.test.test('.svg'));
-    console.log('fileLoaderRule', fileLoaderRule);
 
     fileLoaderRule.exclude = pathToInlineSvg;
 
-    config.module.rules.push({
+    rules.push({
         test: /\.(ts|tsx)$/,
         use: [
             {
@@ -27,7 +25,9 @@ module.exports = ({ config }) => {
             },
         ],
     });
-    config.module.rules.push({
+
+    // Use svgr webpack to import svg as react component
+    rules.push({
         test: /\.svg$/,
         use: [{
         loader: '@svgr/webpack',

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -38,6 +38,7 @@ module.exports = ({ config }) => {
             }
         ],
     });
+
     config.resolve.extensions.push('.ts', '.tsx');
     return config;
 };

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -3,7 +3,19 @@ const constants = require('../constants.js');
 
 const { config } = constants;
 
+const pathToInlineSvg = path.resolve(__dirname, '../../src/app/components/Icon/svg');
+
+
 module.exports = ({ config }) => {
+    console.log('pathToInlineSvg', pathToInlineSvg);
+    const rules = config.module.rules;
+
+    // // modify storybook's file-loader rule to avoid conflicts with svgr
+    const fileLoaderRule = rules.find(rule => rule.test.test('.svg'));
+    console.log('fileLoaderRule', fileLoaderRule);
+
+    fileLoaderRule.exclude = pathToInlineSvg;
+
     config.module.rules.push({
         test: /\.(ts|tsx)$/,
         use: [
@@ -14,6 +26,15 @@ module.exports = ({ config }) => {
                 }
             },
         ],
+    });
+    config.module.rules.push({
+        test: /\.svg$/,
+        use: [{
+        loader: '@svgr/webpack',
+        options: {
+            icon: true,
+        },
+        }],
     });
     config.resolve.extensions.push('.ts', '.tsx');
     return config;

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -29,12 +29,14 @@ module.exports = ({ config }) => {
     // Use svgr webpack to import svg as react component
     rules.push({
         test: /\.svg$/,
-        use: [{
-        loader: '@svgr/webpack',
-        options: {
-            icon: true,
-        },
-        }],
+        use: [
+            {
+                loader: '@svgr/webpack',
+                options: {
+                    icon: true,
+                },
+            }
+        ],
     });
     config.resolve.extensions.push('.ts', '.tsx');
     return config;

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,9 +1,9 @@
 const path = require('path');
 const constants = require('../constants.js');
 
-const { config, APP_DIR } = constants;
+const { config, COMPONENTS_DIR } = constants;
 
-const pathToInlineSvg = path.resolve(APP_DIR, 'components/Icon/svg');
+const pathToInlineSvg = path.resolve(COMPONENTS_DIR, 'Icon/svg');
 
 
 module.exports = ({ config }) => {

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -80,6 +80,10 @@ module.exports.client = {
                 test: /\.css$/,
                 use: ['style-loader', 'css-loader'],
             },
+            {
+                test: /\.svg$/,
+                use: ['@svgr/webpack'],
+            },
         ],
     },
 
@@ -153,6 +157,17 @@ module.exports.server = {
             {
                 test: /\.(s?css|sass)$/,
                 loader: 'ignore-loader',
+            },
+            {
+                test: /\.svg$/,
+                use: [
+                    {
+                        loader: '@svgr/webpack',
+                        options: {
+                            native: true,
+                        },
+                    },
+                ],
             },
         ],
     },

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -82,7 +82,12 @@ module.exports.client = {
             },
             {
                 test: /\.svg$/,
-                use: ['@svgr/webpack'],
+                use: [{
+                    loader: '@svgr/webpack',
+                    options: {
+                        icon: true,
+                    },
+                }],
             },
         ],
     },
@@ -160,14 +165,12 @@ module.exports.server = {
             },
             {
                 test: /\.svg$/,
-                use: [
-                    {
-                        loader: '@svgr/webpack',
-                        options: {
-                            native: true,
-                        },
+                use: [{
+                    loader: '@svgr/webpack',
+                    options: {
+                        icon: true,
                     },
-                ],
+                }],
             },
         ],
     },


### PR DESCRIPTION
# Config Storybook  to use SVGR webpack plugin
- modify storybook's file-loader rule to avoid conflicts with svgr